### PR TITLE
Rename ineditor to bookeditor

### DIFF
--- a/biblatex-nejm.tex
+++ b/biblatex-nejm.tex
@@ -29,8 +29,8 @@
   url={\biblatexctan},
   author={Marco Daniel and Dilum Aluthge},
   email={\,},
-  revision={0.6.0-DEV},
-  date={2019-06-13}}
+  revision={0.6.1-DEV},
+  date={2019-07-19}}
 
 \hypersetup{%
   citecolor=red,

--- a/biblatex-nejm.tex
+++ b/biblatex-nejm.tex
@@ -29,7 +29,7 @@
   url={\biblatexctan},
   author={Marco Daniel and Dilum Aluthge},
   email={\,},
-  revision={0.6.1-DEV},
+  revision={0.7.0-DEV},
   date={2019-07-19}}
 
 \hypersetup{%

--- a/build.lua
+++ b/build.lua
@@ -25,6 +25,7 @@ function update_tag(file, content, tagname, tagdate)
   local isodate_scheme = "%d%d%d%d%-%d%d%-%d%d"
   local ltxdate_scheme = string.gsub(isodate_scheme, "%-", "/")
   local version_scheme = "%d+%.%d+%.%d+"
+  local version_dev_scheme = version_scheme .. "%-DEV"
   local tagdate_ltx  = string.gsub(tagdate, "%-", "/")
   local tagyear      = string.match(tagdate, "%d%d%d%d")
   local tagname_safe = string.gsub(tagname, "^v", "")
@@ -33,15 +34,26 @@ function update_tag(file, content, tagname, tagdate)
   content = string.gsub(content, "Copyright %(c%) 2011%-%d%d%d%d by",
                                  "Copyright (c) 2011-".. tagyear .. " by")
   -- \ProvidesFile
-  if  string.match(file, "%.bbx$")  or string.match(file, "%.cbx$") then
-    return string.gsub(content , ltxdate_scheme .. " v" .. version_scheme,
-                                 tagdate_ltx .. " v" .. tagname_safe)
+  if string.match(file, "%.bbx$")  or string.match(file, "%.cbx$") then
+    if string.match(content, version_dev_scheme) then
+      return string.gsub(content , ltxdate_scheme .. " v" .. version_dev_scheme,
+                                   tagdate_ltx .. " v" .. tagname_safe)
+    else
+      return string.gsub(content , ltxdate_scheme .. " v" .. version_scheme,
+                                   tagdate_ltx .. " v" .. tagname_safe)
+    end
   -- \titlepage stuff
   elseif string.match(file, "%.tex$") then
     content = string.gsub(content, "date%s*=%s*{" .. isodate_scheme .. "}",
                                    "date={" .. tagdate .."}")
-    return string.gsub(content, "revision%s*=%s*{" .. version_scheme .. "}",
-                                "revision={" .. tagname_safe .. "}")
+    
+    if string.match(content, version_dev_scheme) then
+      return string.gsub(content, "revision%s*=%s*{" .. version_dev_scheme .. "}",
+                                  "revision={" .. tagname_safe .. "}")
+    else
+      return string.gsub(content, "revision%s*=%s*{" .. version_scheme .. "}",
+                                  "revision={" .. tagname_safe .. "}")
+    end
   end
   return content
 end

--- a/nejm.bbx
+++ b/nejm.bbx
@@ -20,7 +20,7 @@
 %% This work consists of the files nejm.bbx, nejm.cbx, biblatex-nejm.tex
 %% and biblatex-nejm.pdf
 
-\ProvidesFile{nejm.bbx}[2019/07/19 v0.6.1-DEV NEJM biblatex
+\ProvidesFile{nejm.bbx}[2019/07/19 v0.7.0-DEV NEJM biblatex
   bibliography style (MD/DA)]
 
 %use numeric.cbx as base

--- a/nejm.bbx
+++ b/nejm.bbx
@@ -20,8 +20,8 @@
 %% This work consists of the files nejm.bbx, nejm.cbx, biblatex-nejm.tex
 %% and biblatex-nejm.pdf
 
-\ProvidesFile{nejm.bbx}[2019/06/13 v0.6.0-DEV-DEV-DEV-DEV-DEV-DEV NEJM biblatex bibliography style
-  (MD/DA)]
+\ProvidesFile{nejm.bbx}[2019/07/19 v0.6.1-DEV NEJM biblatex
+  bibliography style (MD/DA)]
 
 %use numeric.cbx as base
 %Warning if backend isn't biber
@@ -75,7 +75,7 @@
 %Set name format
 \DeclareNameAlias{default}{family-given}
 \DeclareNameAlias{sortname}{family-given}
-\DeclareNameAlias{ineditor}{default}
+\DeclareNameAlias{bookeditor}{default}
 \renewrobustcmd*{\bibinitperiod}{}
 \renewcommand*{\revsdnamepunct}{}
 
@@ -189,7 +189,7 @@
     and
     not test {\ifnameundef{editor}}
   }
-    {\printnames[ineditor]{editor}%
+    {\printnames[bookeditor]{editor}%
      \setunit{\printdelim{editortypedelim}}%
      \usebibmacro{editor+othersstrg}%
      \clearname{editor}}

--- a/nejm.cbx
+++ b/nejm.cbx
@@ -2,7 +2,7 @@
 %% Please submit all feedback, issues, and pull requests to:
 %% https://github.com/marcodaniel/biblatex-nejm
 
-\ProvidesFile{nejm.cbx}[2019/07/19 v0.6.1-DEV NEJM biblatex
+\ProvidesFile{nejm.cbx}[2019/07/19 v0.7.0-DEV NEJM biblatex
   citation style (MD/DA)]
 
 \RequireCitationStyle{numeric-comp}

--- a/nejm.cbx
+++ b/nejm.cbx
@@ -2,8 +2,8 @@
 %% Please submit all feedback, issues, and pull requests to:
 %% https://github.com/marcodaniel/biblatex-nejm
 
-\ProvidesFile{nejm.cbx}[2019/06/13 v0.6.0-DEV-DEV-DEV-DEV-DEV-DEV NEJM biblatex citation style
-  (MD/DA)]
+\ProvidesFile{nejm.cbx}[2019/07/19 v0.6.1-DEV NEJM biblatex
+  citation style (MD/DA)]
 
 \RequireCitationStyle{numeric-comp}
 


### PR DESCRIPTION
Rename the name format `ineditor` to `bookeditor`. This is more consistent with the field name `bookauthor`.

Also fix "-DEV"s building up in the version number.